### PR TITLE
Replace auto_ptr with unique_ptr

### DIFF
--- a/stack_cleaner.hpp
+++ b/stack_cleaner.hpp
@@ -72,7 +72,7 @@ class stack_cleaner {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
     /// Disallow copies.
     stack_cleaner(const stack_cleaner&);


### PR DESCRIPTION
auto_ptr is removed in C++17 and later

Closes #7.