### PR TITLE
Revert "Remove support below C++11"

### DIFF
--- a/debug.hpp
+++ b/debug.hpp
@@ -33,7 +33,11 @@
 #define LUTOK_DEBUG_HPP
 
 #include <string>
+#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
 #include <memory>
+#else
+#include <tr1/memory>
+#endif
 
 namespace lutok {
 
@@ -55,7 +59,11 @@ class debug {
     struct impl;
 
     /// Pointer to the shared internal implementation.
+#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
     std::shared_ptr< impl > _pimpl;
+#else
+    std::tr1::shared_ptr< impl > _pimpl;
+#endif
 
 public:
     debug(void);

--- a/m4/compiler-features.m4
+++ b/m4/compiler-features.m4
@@ -44,8 +44,6 @@ AC_DEFUN([KYUA_REQUIRE_CXX], [
     if test "${atf_cv_prog_cxx_works}" = no; then
         AC_MSG_ERROR([C++ compiler cannot create executables])
     fi
-
-    AX_CXX_COMPILE_STDCXX_11([], [])
 ])
 
 dnl

--- a/state.hpp
+++ b/state.hpp
@@ -34,7 +34,11 @@
 
 #include <string>
 
+#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
 #include <memory>
+#else
+#include <tr1/memory>
+#endif
 
 namespace lutok {
 
@@ -73,7 +77,11 @@ class state {
     struct impl;
 
     /// Pointer to the shared internal implementation.
+#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
     std::shared_ptr< impl > _pimpl;
+#else
+    std::tr1::shared_ptr< impl > _pimpl;
+#endif
 
     void* new_userdata_voidp(const size_t);
     void* to_userdata_voidp(const int);


### PR DESCRIPTION
Unfortunately I missed the fact that this requires ax_cxx_compile_stdcxx.m4 .

CC: @fel1x-developer 

Reverts freebsd/lutok#15