### PR TITLE
Remove support below C++11

### DIFF
--- a/debug.hpp
+++ b/debug.hpp
@@ -33,11 +33,7 @@
 #define LUTOK_DEBUG_HPP
 
 #include <string>
-#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
 #include <memory>
-#else
-#include <tr1/memory>
-#endif
 
 namespace lutok {
 
@@ -59,11 +55,7 @@ class debug {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
     std::shared_ptr< impl > _pimpl;
-#else
-    std::tr1::shared_ptr< impl > _pimpl;
-#endif
 
 public:
     debug(void);

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -1,0 +1,39 @@
+# =============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_11.html
+# =============================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX_11([ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the C++11
+#   standard; if necessary, add switches to CXX and CXXCPP to enable
+#   support.
+#
+#   This macro is a convenience alias for calling the AX_CXX_COMPILE_STDCXX
+#   macro with the version set to C++11.  The two optional arguments are
+#   forwarded literally as the second and third argument respectively.
+#   Please see the documentation for the AX_CXX_COMPILE_STDCXX macro for
+#   more information.  If you want to use this macro, you also need to
+#   download the ax_cxx_compile_stdcxx.m4 file.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 18
+
+AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [AX_CXX_COMPILE_STDCXX([11], [$1], [$2])])

--- a/m4/compiler-features.m4
+++ b/m4/compiler-features.m4
@@ -44,6 +44,8 @@ AC_DEFUN([KYUA_REQUIRE_CXX], [
     if test "${atf_cv_prog_cxx_works}" = no; then
         AC_MSG_ERROR([C++ compiler cannot create executables])
     fi
+
+    AX_CXX_COMPILE_STDCXX_11([], [])
 ])
 
 dnl

--- a/state.hpp
+++ b/state.hpp
@@ -34,11 +34,7 @@
 
 #include <string>
 
-#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
 #include <memory>
-#else
-#include <tr1/memory>
-#endif
 
 namespace lutok {
 
@@ -77,11 +73,7 @@ class state {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-#if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
     std::shared_ptr< impl > _pimpl;
-#else
-    std::tr1::shared_ptr< impl > _pimpl;
-#endif
 
     void* new_userdata_voidp(const size_t);
     void* to_userdata_voidp(const int);


### PR DESCRIPTION
Reverts freebsd/lutok#16

Should I include `ax_cxx_compile_stdcxx.m4`?

Example: GNU GCC
https://github.com/gcc-mirror/gcc/blob/master/configure.ac#L26