### PR TITLE
Update URLs to reference freebsd org instead of jmmv's personal account

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -176,6 +176,6 @@ follows:
 
 And if you see any tests fail, do not hesitate to report them in:
 
-    https://github.com/jmmv/lutok/issues/
+    https://github.com/freebsd/lutok/issues/
 
 Thank you!

--- a/README
+++ b/README
@@ -24,4 +24,4 @@ please refer to the following other documents:
 
 For general project information, please visit:
 
-    https://github.com/jmmv/lutok/
+    https://github.com/freebsd/lutok/

--- a/admin/travis-install-deps.sh
+++ b/admin/travis-install-deps.sh
@@ -57,7 +57,7 @@ install_from_github() {
 
     local distname="${name}-${release}"
 
-    local baseurl="https://github.com/jmmv/${project}"
+    local baseurl="https://github.com/freebsd/${project}"
     wget --no-check-certificate \
         "${baseurl}/releases/download/${distname}/${distname}.tar.gz"
     tar -xzvf "${distname}.tar.gz"
@@ -95,7 +95,7 @@ install_from_bintray() {
             exit 1
             ;;
     esac
-    wget "http://dl.bintray.com/jmmv/kyua/${name}" || return 1
+    wget "http://dl.bintray.com/freebsd/kyua/${name}" || return 1
     sudo tar -xzvp -C / -f "${name}"
     rm -f "${name}"
 }

--- a/configure.ac
+++ b/configure.ac
@@ -27,9 +27,9 @@ dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 AC_INIT([Lutok], [0.4],
-        [lutok-discuss@googlegroups.com], [lutok],
-        [https://github.com/jmmv/lutok/])
-AC_PREREQ([2.65])
+        [testing@FreeBSD.org], [lutok],
+        [https://github.com/freebsd/lutok/])
+AC_PREREQ([2.68])
 
 
 AC_COPYRIGHT([Copyright 2011 Google Inc.])


### PR DESCRIPTION
This finishes documenting the transition for multiple kyua-related
projects from @jmmv's personal GitHub account to the @freebsd github
org.