### PR TITLE
Resolve a benign buffer overrun issue

### DIFF
--- a/state.cpp
+++ b/state.cpp
@@ -145,10 +145,10 @@ call_cxx_function_from_c(lutok::cxx_function function,
         lutok::state state = lutok::state_c_gate::connect(raw_state);
         return function(state);
     } catch (const std::exception& e) {
-        std::strncpy(error_buf, e.what(), sizeof(error_buf));
+        std::strncpy(error_buf, e.what(), sizeof(error_buf) - 1);
     } catch (...) {
         std::strncpy(error_buf, "Unhandled exception in Lua C++ hook",
-                     sizeof(error_buf));
+                     sizeof(error_buf) - 1);
     }
     error_buf[sizeof(error_buf) - 1] = '\0';
     // We raise the Lua error from outside the try/catch context and we use


### PR DESCRIPTION
The actual size that should be passed to `std::strncpy` is `sizeof(..) - 1`, not `sizeof(..)`. The former pattern avoids a benign potential buffer overrun issue.

Reported by:	gcc 13.2