### PR TITLE
m4/lua.m4: make detection work again with pkgconf

### DIFF
--- a/m4/lua.m4
+++ b/m4/lua.m4
@@ -34,18 +34,16 @@ dnl
 AC_DEFUN([KYUA_LUA], [
     lua_found=no
     for lua_release in ${LUA_VERSION:-5.4 5.3}; do
-        AS_IF([test "${lua_found}" = no],[
-            PKG_CHECK_MODULES([LUA], [lua${lua_release} >= ${lua_release}],
-                              [lua_found="lua${lua_release}"; break],[])
-        ])
-        AS_IF([test "${lua_found}" = no],[
-            PKG_CHECK_MODULES([LUA], [lua-${lua_release} >= ${lua_release}],
-                              [lua_found="lua-${lua_release}"; break],[])
-        ])
-        AS_IF([test "${lua_found}" = no],[
-            PKG_CHECK_MODULES([LUA], [lua >= ${lua_release}],
-                              [lua_found=lua; break],[])
-        ])
+        PKG_CHECK_MODULES([LUA], [lua-${lua_release} >= ${lua_release}],
+            [lua_found="lua-${lua_release}"],[
+        PKG_CHECK_MODULES([LUA], [lua${lua_release} >= ${lua_release}],
+            [lua_found="lua${lua_release}"],[
+        PKG_CHECK_MODULES([LUA], [lua >= ${lua_release}],
+            [lua_found="lua"],[])
+        ])])
+        if test "${lua_found}" != no; then
+            break
+        fi
     done
 
     AS_IF([test "${lua_found}" = no],[],[


### PR DESCRIPTION
It seems that `break` isn't allowed in else blocks with m4 macros. Change the logic to flow in a manner that works with the `PKG_CHECK_MODULES` macro.

This unbreaks the build on FreeBSD with ports.

Fixes:	02a2b33f7beff0a014e2373454239e3bebf2d7b5